### PR TITLE
Exclude the padded NULL when comparing the file size

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -344,6 +344,7 @@ vars_del_variable(efi_guid_t guid, const char *name)
 		goto err;
 
 	rc = read_file(fd, &buf, &buf_size);
+	buf_size -= 1; /* read_file pads out 1 extra byte to NUL it */
 	if (rc < 0 || (buf_size != sizeof(efi_kernel_variable_64_t) &&
 		       buf_size != sizeof(efi_kernel_variable_32_t)))
 		goto err;


### PR DESCRIPTION
In vars_del_variable(), this "if" statement always failed because
read_file() returned the actual file size +1.

if (rc < 0 || (buf_size != sizeof(efi_kernel_variable_64_t) &&
               buf_size != sizeof(efi_kernel_variable_32_t)))

Signed-off-by: Gary Ching-Pang Lin <glin@suse.com>