### PR TITLE
efi_loadopt_create : Allow "dp = NULL" if "size = 0"

### DIFF
--- a/src/loadopt.c
+++ b/src/loadopt.c
@@ -36,24 +36,27 @@ efi_loadopt_create(uint8_t *buf, ssize_t size, uint32_t attributes,
 		   efidp dp, ssize_t dp_size, unsigned char *description,
 		   uint8_t *optional_data, size_t optional_data_size)
 {
-	if (!description || (!optional_data && optional_data_size != 0)) {
+	ssize_t desc_len;
+	ssize_t sz;
+	
+	if (!description || dp_size == 0) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	if (!dp && dp_size == 0) {
-		errno = EINVAL;
-		return -1;
-	}
-
-	ssize_t desc_len = utf8len((uint8_t *)description, 1024) * 2 + 2;
-	ssize_t sz = sizeof (attributes)
+	desc_len = utf8len((uint8_t *)description, 1024) * 2 + 2;
+	sz = sizeof (attributes)
 		     + sizeof (uint16_t) + desc_len
 		     + dp_size + optional_data_size;
+
 	if (size == 0)
 		return sz;
 	if (size < sz) {
 		errno = ENOSPC;
+		return -1;
+	}
+	if (!dp || (!optional_data && optional_data_size > 0)) {
+		errno = EINVAL;
 		return -1;
 	}
 


### PR DESCRIPTION
This fix the issue https://github.com/rhinstaller/efibootmgr/issues/36