### PR TITLE
Remove -fno-wchar from cpp_options

### DIFF
--- a/gcc.specs
+++ b/gcc.specs
@@ -2,7 +2,7 @@
 + -D_GNU_SOURCE
 
 *efivar_cpp_options:
- -Werror -Wall -std=gnu11 -fshort-wchar
+ -Werror -Wall -std=gnu11
 
 *cpp_options:
 + %(efivar_cpp_options)

--- a/src/ucs2.h
+++ b/src/ucs2.h
@@ -9,7 +9,7 @@ __attribute__((__unused__))
 ucs2len(const uint16_t * const s, ssize_t limit)
 {
 	ssize_t i;
-	for (i = 0; i < (limit >= 0 ? limit : i+1) && s[i] != L'\0'; i++)
+	for (i = 0; i < (limit >= 0 ? limit : i+1) && s[i] != (uint16_t)0; i++)
 		;
 	return i;
 }
@@ -156,7 +156,7 @@ utf8_to_ucs2(uint16_t *ucs2, ssize_t size, int terminate, uint8_t *utf8)
 		ucs2[j] = val;
 	}
 	if (terminate)
-		ucs2[j++] = L'\0';
+		ucs2[j++] = (uint16_t)0;
 	return j;
 };
 


### PR DESCRIPTION
For an EFI service the option makes much sense but not so for a set of linux libraries and tools.