### PR TITLE
Fix some warnings caught by -Werror=format-security

### DIFF
--- a/src/creator.c
+++ b/src/creator.c
@@ -201,7 +201,7 @@ efi_va_generate_file_device_path_from_esp(uint8_t *buf, ssize_t size,
 		 * symlink from /sys/dev/block/$major:$minor and get it
 		 * from there.
 		 */
-		sz = make_blockdev_path(buf, size, fd, &info);
+		sz = make_blockdev_path(buf, size, &info);
 		if (sz < 0)
 			return -1;
 		off += sz;

--- a/src/linux.c
+++ b/src/linux.c
@@ -152,7 +152,7 @@ get_partition_number(const char *devpath)
 }
 
 static int
-sysfs_test_nvme(const char *buf, ssize_t size)
+sysfs_test_nvme(const char *buf)
 {
 	int rc;
 
@@ -261,7 +261,7 @@ sysfs_sata_get_port_info(uint32_t print_id, struct disk_info *info)
 
 static ssize_t
 sysfs_parse_nvme(uint8_t *buf, ssize_t size, ssize_t *off,
-		const char *pbuf, ssize_t psize, ssize_t *poff,
+		const char *pbuf, ssize_t *poff,
 		struct disk_info *info)
 {
 	int rc;
@@ -665,7 +665,7 @@ make_pci_path(uint8_t *buf, ssize_t size, char *pathstr, ssize_t *pathoff)
 
 int
 __attribute__((__visibility__ ("hidden")))
-make_blockdev_path(uint8_t *buf, ssize_t size, int fd, struct disk_info *info)
+make_blockdev_path(uint8_t *buf, ssize_t size, struct disk_info *info)
 {
 	char *linkbuf = NULL;
 	char *driverbuf = NULL;
@@ -735,13 +735,13 @@ make_blockdev_path(uint8_t *buf, ssize_t size, int fd, struct disk_info *info)
 	 * /sys/dev/block/259:0 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1
 	 */
 	if (!found) {
-		rc = sysfs_test_nvme(linkbuf+loff, PATH_MAX-off);
+		rc = sysfs_test_nvme(linkbuf+loff);
 		if (rc < 0)
 			return -1;
 		else if (rc > 0) {
 			ssize_t linksz;
 			rc = sysfs_parse_nvme(buf+off, size?size-off:0, &sz,
-					      linkbuf+loff, PATH_MAX-off,
+					      linkbuf+loff,
 					      &linksz, info);
 			if (rc < 0)
 				return -1;

--- a/src/linux.h
+++ b/src/linux.h
@@ -98,7 +98,7 @@ enum _interface_type {interface_type_unknown,
 
 extern int eb_disk_info_from_fd(int fd, struct disk_info *info);
 extern int set_disk_and_part_name(struct disk_info *info);
-extern int make_blockdev_path(uint8_t *buf, ssize_t size, int fd,
+extern int make_blockdev_path(uint8_t *buf, ssize_t size,
 				struct disk_info *info);
 
 extern int eb_nvme_ns_id(int fd, uint32_t *ns_id);


### PR DESCRIPTION
These were introduced in 8910f45.

Build snippet:

```
gcc -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -I/home/test/src/efivar/src/include/efivar/  -specs=/home/test/src/efivar/gcc.specs  -fPIC -Wdate-time -D_FORTIFY_SOURCE=2 -c -o linux.o linux.c
linux.c: In function ‘sysfs_test_nvme’:
linux.c:155:42: error: unused parameter ‘size’ [-Werror=unused-parameter]
 sysfs_test_nvme(const char *buf, ssize_t size)
                                          ^
linux.c: In function ‘sysfs_parse_nvme’:
linux.c:264:29: error: unused parameter ‘psize’ [-Werror=unused-parameter]
   const char *pbuf, ssize_t psize, ssize_t *poff,
                             ^
linux.c: In function ‘make_blockdev_path’:
linux.c:668:52: error: unused parameter ‘fd’ [-Werror=unused-parameter]
 make_blockdev_path(uint8_t *buf, ssize_t size, int fd, struct disk_info *info)
                                                    ^
cc1: all warnings being treated as errors
```

As far as I can tell no one is actually using make_blockdev_path outside of efivar.