### PR TITLE
fwupdate fails to generate a valid DP on NVMe SSD's

### DIFF
--- a/src/creator.c
+++ b/src/creator.c
@@ -307,7 +307,7 @@ efi_generate_file_device_path(uint8_t *buf, ssize_t size,
 	va_start(ap, options);
 
 	ret = efi_va_generate_file_device_path_from_esp(buf, size, devpath,
-						       0, relpath, options, ap);
+						       rc, relpath, options, ap);
 	saved_errno = errno;
 	va_end(ap);
 	errno = saved_errno;

--- a/src/creator.c
+++ b/src/creator.c
@@ -291,30 +291,37 @@ efi_generate_file_device_path(uint8_t *buf, ssize_t size,
 {
 	int rc;
 	ssize_t ret = -1;
-	char *devpath = NULL;
+	char *child_devpath = NULL;
+	char *parent_devpath = NULL;
 	char *relpath = NULL;
 	va_list ap;
 	int saved_errno;
 
-	rc = find_file(filepath, &devpath, &relpath);
+	rc = find_file(filepath, &child_devpath, &relpath);
 	if (rc < 0)
 		return -1;
 
-	rc = get_partition_number(devpath);
+	rc = find_parent_devpath(child_devpath, &parent_devpath);
+	if (rc < 0)
+		return -1;
+
+	rc = get_partition_number(child_devpath);
 	if (rc < 0)
 		goto err;
 
 	va_start(ap, options);
 
-	ret = efi_va_generate_file_device_path_from_esp(buf, size, devpath,
+	ret = efi_va_generate_file_device_path_from_esp(buf, size, parent_devpath,
 						       rc, relpath, options, ap);
 	saved_errno = errno;
 	va_end(ap);
 	errno = saved_errno;
 err:
 	saved_errno = errno;
-	if (devpath)
-		free(devpath);
+	if (child_devpath)
+		free(child_devpath);
+	if (parent_devpath)
+			free(parent_devpath);
 	if (relpath)
 		free(relpath);
 	errno = saved_errno;

--- a/src/creator.c
+++ b/src/creator.c
@@ -201,7 +201,7 @@ efi_va_generate_file_device_path_from_esp(uint8_t *buf, ssize_t size,
 		 * symlink from /sys/dev/block/$major:$minor and get it
 		 * from there.
 		 */
-		sz = make_blockdev_path(buf, size, fd, &info);
+		sz = make_blockdev_path(buf, size, &info);
 		if (sz < 0)
 			return -1;
 		off += sz;

--- a/src/linux.c
+++ b/src/linux.c
@@ -152,7 +152,7 @@ get_partition_number(const char *devpath)
 }
 
 static int
-sysfs_test_nvme(const char *buf, ssize_t size)
+sysfs_test_nvme(const char *buf)
 {
 	int rc;
 
@@ -261,7 +261,7 @@ sysfs_sata_get_port_info(uint32_t print_id, struct disk_info *info)
 
 static ssize_t
 sysfs_parse_nvme(uint8_t *buf, ssize_t size, ssize_t *off,
-		const char *pbuf, ssize_t psize, ssize_t *poff,
+		const char *pbuf, ssize_t *poff,
 		struct disk_info *info)
 {
 	int rc;
@@ -665,7 +665,7 @@ make_pci_path(uint8_t *buf, ssize_t size, char *pathstr, ssize_t *pathoff)
 
 int
 __attribute__((__visibility__ ("hidden")))
-make_blockdev_path(uint8_t *buf, ssize_t size, int fd, struct disk_info *info)
+make_blockdev_path(uint8_t *buf, ssize_t size, struct disk_info *info)
 {
 	char *linkbuf = NULL;
 	char *driverbuf = NULL;
@@ -735,13 +735,13 @@ make_blockdev_path(uint8_t *buf, ssize_t size, int fd, struct disk_info *info)
 	 * /sys/dev/block/259:0 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1
 	 */
 	if (!found) {
-		rc = sysfs_test_nvme(linkbuf+loff, PATH_MAX-off);
+		rc = sysfs_test_nvme(linkbuf+loff);
 		if (rc < 0)
 			return -1;
 		else if (rc > 0) {
 			ssize_t linksz;
 			rc = sysfs_parse_nvme(buf+off, size?size-off:0, &sz,
-					      linkbuf+loff, PATH_MAX-off,
+					      linkbuf+loff,
 					      &linksz, info);
 			if (rc < 0)
 				return -1;

--- a/src/linux.h
+++ b/src/linux.h
@@ -106,6 +106,9 @@ extern int eb_nvme_ns_id(int fd, uint32_t *ns_id);
 extern int get_partition_number(const char *devpath)
 	__attribute__((__visibility__ ("hidden")));
 
+extern int find_parent_devpath(const char * const child, char **parent)
+	__attribute__((__visibility__ ("hidden")));
+
 extern ssize_t make_mac_path(uint8_t *buf, ssize_t size,
 			     const char * const ifname)
 	__attribute__((__visibility__ ("hidden")));

--- a/src/linux.h
+++ b/src/linux.h
@@ -98,7 +98,7 @@ enum _interface_type {interface_type_unknown,
 
 extern int eb_disk_info_from_fd(int fd, struct disk_info *info);
 extern int set_disk_and_part_name(struct disk_info *info);
-extern int make_blockdev_path(uint8_t *buf, ssize_t size, int fd,
+extern int make_blockdev_path(uint8_t *buf, ssize_t size,
 				struct disk_info *info);
 
 extern int eb_nvme_ns_id(int fd, uint32_t *ns_id);


### PR DESCRIPTION
I thought this was really odd since efibootmgr was able to start generating valid DP's
after 3f5c2df68a098810b5bf1cbaed4c31c59c14bf3f.

Digging further into the code it's because efibootmgr follows a codepath that it
feeds the disk path (eg /dev/nvme0n1) and partition (eg 1).

The codepath followed for fwupdate just provides a file path and efivar is supposed
to figure out what disk it's on.  It does this part fine, but the variable it fills
(devpath) ends up having the device node pointing to the partition.

This is obviously OK for SATA disks (otherwise it would have been caught a lot sooner!).
On NVMe disks however it causes a bogus disk to be built later in the code.
IIRC /dev/nvmen1p1p1 or something like that.

So this patch set finds the disk that the partition node points to be walking sysfs
backwards.  I've confirmed on NVMe disks this generates a valid DP now.
