### PR TITLE
efidp_format_device_path: add enough input argument checking to avoid…

### DIFF
--- a/src/dp.c
+++ b/src/dp.c
@@ -260,6 +260,9 @@ efidp_format_device_path(char *buf, size_t size, const_efidp dp, ssize_t limit)
 	ssize_t off = 0;
 	int first = 1;
 
+	if (!dp) {
+		return -1;
+	}
 	while (1) {
 		if (limit >= 0 && (limit < 4 || efidp_node_size(dp) > limit)) {
 			if (off)


### PR DESCRIPTION
For your consideration, these changes are sufficient to avoid a possible coredump when running efibootmgr -v.

```
Core was generated by `efibootmgr -v'.
#0  0x00007f63644b3257 in efidp_format_device_path (buf=0x0, size=0, dp=0x0, limit=13) at dp.c:284
284	dp.c: No such file or directory.
(gdb) bt
#0  0x00007f63644b3257 in efidp_format_device_path (buf=0x0, size=0, dp=0x0, limit=13) at dp.c:284
#1  0x0000000000403177 in show_boot_vars () at efibootmgr.c:852
#2  main (argc=<optimized out>, argv=<optimized out>) at efibootmgr.c:1533
(gdb) quit
```