### PR TITLE
Make.rules: fix build with make <= 3.81

### DIFF
--- a/Make.rules
+++ b/Make.rules
@@ -42,7 +42,7 @@ include $(TOPDIR)/Make.version
 
 %.c : %.h
 
-define substitute-version =
+define substitute-version
 	sed						\
 		-e "s,@@VERSION@@,$(VERSION),g"		\
 		-e "s,@@LIBDIR@@,$(libdir),g"		\
@@ -61,7 +61,7 @@ pkg-config-ldflags = \
 pkg-config-ldlibs = \
 	$(shell if [ -n "$(PKGS)" ]; then $(PKG_CONFIG) --libs-only-l $(PKGS) ; fi)
 
-define deps-of =
+define deps-of
 	$(foreach src,$(filter %.c,$(1)),$(patsubst %.c,.%.d,$(src))) \
 	$(foreach src,$(filter %.S,$(1)),$(patsubst %.S,.%.d,$(src)))
 endef


### PR DESCRIPTION
Building with host make 3.81 resulted in an issue where src/efivar.pc
was never generated.
Even by running 'make efivar.pc' inside the src directory, make always
returned that there was nothing to do.
This was not observed when using make 3.82 or 4.x.
It is apparently caused by the assignment operators in the multi-line
defines in Make.rules, which do not seem to be supported by make 3.81.
By omitting the assignment operators, the rule works with both versions
of make.

Signed-off-by: Erico Nunes <nunes.erico@gmail.com>