### PR TITLE
Include sys/sysmacros.h when sys/types.h does not define major

### DIFF
--- a/src/linux.c
+++ b/src/linux.c
@@ -36,6 +36,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#ifndef major
+#include <sys/sysmacros.h>
+#endif
+
 #include <efivar.h>
 #include <efiboot.h>
 


### PR DESCRIPTION
glibc is planning to drop this from sys/types.h.

See also https://bugs.gentoo.org/580142.