### PR TITLE
clang++ efi_guid_is_empty alias issue

### DIFF
--- a/src/include/efivar/efivar.h
+++ b/src/include/efivar/efivar.h
@@ -115,7 +115,7 @@ efi_guid_cmp(const efi_guid_t *a, const efi_guid_t *b)
 
 extern const efi_guid_t efi_guid_zero;
 
-static inline int
+inline int
 __attribute__ ((unused))
 __attribute__((__nonnull__ (1)))
 efi_guid_is_zero(const efi_guid_t *guid)


### PR DESCRIPTION
As efi_guid_is_zero is static function, its name is mangled and the
__attribute__ ((weak, alias ("efi_guid_is_zero"))) is failing with
clang++.

Making efi_guid_is_zero a non-static function.

Signed-off-by: Jeremy Compostella <jeremy.compostella@intel.com>