### PR TITLE
Multiple fixes for SATA device paths.

### DIFF
--- a/src/dp-message.c
+++ b/src/dp-message.c
@@ -641,7 +641,7 @@ efidp_make_nvme(uint8_t *buf, ssize_t size, uint32_t namespace_id,
 ssize_t
 __attribute__((__visibility__ ("default")))
 efidp_make_sata(uint8_t *buf, ssize_t size, uint16_t hba_port,
-		uint16_t port_multiplier_port, uint16_t lun)
+		int16_t port_multiplier_port, uint16_t lun)
 {
 	efidp_sata *sata = (efidp_sata *)buf;
 	ssize_t req = sizeof (*sata);

--- a/src/include/efivar/efivar-dp.h
+++ b/src/include/efivar/efivar-dp.h
@@ -269,7 +269,7 @@ typedef struct {
 } efidp_sata;
 #define SATA_HBA_DIRECT_CONNECT_FLAG	0x8000
 extern ssize_t efidp_make_sata(uint8_t *buf, ssize_t size, uint16_t hba_port,
-			       uint16_t port_multiplier_port, uint16_t lun);
+			       int16_t port_multiplier_port, uint16_t lun);
 
 #define	EFIDP_MSG_I2O		0x06
 typedef struct {

--- a/src/linux.c
+++ b/src/linux.c
@@ -305,6 +305,17 @@ sysfs_sata_get_port_info(uint32_t print_id, struct disk_info *info)
 	if (rc != 1)
 		return -1;
 
+	/*
+	 * ata_port numbers are 1-indexed from libata in the kernel, but
+	 * they're 0-indexed in the spec.  For maximal confusion.
+	 */
+	if (info->sata_info.ata_port == 0) {
+		errno = EINVAL;
+		return -1;
+	} else {
+		info->sata_info.ata_port -= 1;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
We normally see HD(...) rather than PciRoot(0x0)/.../Sata()/HD(...) device paths, so this has gone unnoticed, but https://github.com/rhinstaller/efibootmgr/issues/47 shows us that we've got two bugs enumerating Linux SATA devices and making device paths for them.

These produce bootable entries which look correct with "efibootmgr -c -L test -l '\EFI\fedora\shim.efi' -d /dev/sda -p1 -e 3" on the Dell XPS 13 9350 in front of me. They look like 0001 here:

> 
> trillian:~/devel/github.com/efibootmgr$ sudo ./src/efibootmgr -v
> BootCurrent: 0000
> Timeout: 0 seconds
> BootOrder: 0001,0000
> Boot0000* Fedora	HD(1,GPT,2cf5261b-7b98-48c0-ae54-463dbd23e65b,0x800,0x64000)/File(\EFI\fedora\shim.efi)
> Boot0001* test	PciRoot(0x0)/Pci(0x17,0x0)/Sata(2,65535,0)/HD(1,GPT,2cf5261b-7b98-48c0-ae54-463dbd23e65b,0x800,0x64000)/File(\EFI\fedora\shim.efi)
> 
