### PR TITLE
gcc.specs: link: change '-PIE' to '-pie' and drop '-PIC'

### DIFF
--- a/gcc.specs
+++ b/gcc.specs
@@ -14,4 +14,4 @@
 + %{!shared:%{!static:%{!r:-pie}}} %{static:-Wl,-no-fatal-warnings -Wl,-static -static -Wl,-z,relro,-z,now}
 
 *link:
-+ %{!static:--fatal-warnings} --no-undefined-version --no-allow-shlib-undefined --add-needed -z now --build-id %{!static:%{!shared:-PIE}} %{shared:-z relro -PIC} %{static:%<pie}
++ %{!static:--fatal-warnings} --no-undefined-version --no-allow-shlib-undefined --add-needed -z now --build-id %{!static:%{!shared:-pie}} %{shared:-z relro} %{static:%<pie}

--- a/gcc.specs
+++ b/gcc.specs
@@ -14,4 +14,4 @@
 + %{!shared:%{!static:%{!r:-pie}}} %{static:-Wl,-no-fatal-warnings -Wl,-static -static -Wl,-z,relro,-z,now}
 
 *link:
-+ %{!static:--fatal-warnings} --no-undefined-version --no-allow-shlib-undefined --add-needed -z now --build-id %{!static:%{!shared:-pie}} %{shared:-z relro} %{static:%<pie}
++ %{!static:--fatal-warnings} --no-undefined-version --no-allow-shlib-undefined -z now --build-id %{!static:%{!shared:-pie}} %{shared:-z relro} %{static:%<pie}


### PR DESCRIPTION
The ld manual does not mention -PIE or -PIC, and ld.gold fails when passed
either option.

The gcc manual mentions that -pie should be passed when linking objects
compiled with -fPIE.

Resolves: https://github.com/rhinstaller/efivar/issues/57
