### PR TITLE
_format_message_dn(): fix the check for a label in the EFIDP_MSG_VENDOR case.

### DIFF
--- a/src/dp-message.c
+++ b/src/dp-message.c
@@ -382,7 +382,8 @@ _format_message_dn(char *buf, size_t size, const_efidp dp)
 					  &dp->msg_vendor.vendor_guid))
 				continue;
 
-			label = subtypes[i].label;
+			if (subtypes[i].label[0])
+				label = subtypes[i].label;
 			formatter = subtypes[i].formatter;
 			break;
 		}


### PR DESCRIPTION
Signed-off-by: Peter Jones <pjones@redhat.com>