### PR TITLE
Use -z muldefs to avoid the multiple definitions bug without -flto

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -32,6 +32,7 @@ cflags	= $(CFLAGS) -I${TOPDIR}/src/include/efivar/ \
 clang_ccldflags =
 gcc_ccldflags =
 ccldflags = $(cflags) -L. $(CCLDFLAGS) $(LDFLAGS) \
+	-Wl,-z,muldefs \
 	$(if $(findstring clang,$(CCLD)),$(clang_ccldflags),) \
 	$(if $(findstring gcc,$(CCLD)),$(gcc_ccldflags),) \
 	$(call pkg-config-ccldflags)


### PR DESCRIPTION
This fixes github issue #64

Signed-off-by: Peter Jones pjones@redhat.com
