### PR TITLE
format_media_dn: Fix formatting of disk signature for MBR partitions

### DIFF
--- a/src/dp-media.c
+++ b/src/dp-media.c
@@ -36,8 +36,11 @@ _format_media_dn(char *buf, size_t size, const_efidp dp)
 		switch (dp->hd.signature_type) {
 		case EFIDP_HD_SIGNATURE_MBR:
 			format(buf, size, off, "HD",
-			       "MBR,0x%"PRIu32",0x%"PRIx64",0x%"PRIx64")",
-			       *(char *)dp->hd.signature,
+			       "MBR,0x%"PRIx32",0x%"PRIx64",0x%"PRIx64")",
+			       (uint32_t)dp->hd.signature[0] |
+			       ((uint32_t)dp->hd.signature[1] << 8) |
+			       ((uint32_t)dp->hd.signature[2] << 16) |
+			       ((uint32_t)dp->hd.signature[3] << 24),
 			       dp->hd.start, dp->hd.size);
 			break;
 		case EFIDP_HD_SIGNATURE_GUID:


### PR DESCRIPTION
The previous logic sign-extended the least-significant byte of the disk
signature and returned a decimal number prefixed with "0x", producing
nonsense like this:

    # blkid -o value -s PTUUID /dev/sdb
    927a7490
    # efibootmgr -v | grep debian
    Boot0002* debian HD(3,MBR,0x4294967184,0xe89c0000,0x100000)/File(\EFI\debian\grubx64.efi)
    # python -c 'print hex(4294967184)'
    0xffffff90

With this change, it works properly:

    Boot0002* debian HD(3,MBR,0x927a7490,0xe89c0000,0x100000)/File(\EFI\debian\grubx64.efi)

Signed-off-by: Dwayne Litzenberger <dlitz@dlitz.net>