### PR TITLE
libefivar: drop conditional include of sys/sysmacros.h

### DIFF
--- a/src/linux.c
+++ b/src/linux.c
@@ -37,10 +37,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#ifndef major
-#include <sys/sysmacros.h>
-#endif
-
 #include <efivar.h>
 #include <efiboot.h>
 


### PR DESCRIPTION
This reverts commit c5685d8d as it has been obsoleted by commit 3ad5aab6.